### PR TITLE
Fixes: Running "jshint:ignore_warning" (jshint) task

### DIFF
--- a/jmespath.js
+++ b/jmespath.js
@@ -529,7 +529,7 @@
       nudQuotedIdentifier: function(token) {
           var node = {type: "Field", name: token.value};
           if (this.lookahead(0) === "Lparen") {
-            var error = new Error("Quoted identifier not allowed for function names.")
+            var error = new Error("Quoted identifier not allowed for function names.");
             error.lineNumber = token.start;
               throw error;
           } else {
@@ -885,8 +885,8 @@
                   return field;
               }
           } else {
-            value = this.scopeChain.resolveReference(node.name)
-            if(value != null && typeof value != 'undefined') {
+            value = this.scopeChain.resolveReference(node.name);
+            if(value !== null && typeof value !== 'undefined') {
               return value;
             }
             return null;


### PR DESCRIPTION
```
   jmespath.js
    532 |            var error = new Error("Quoted identifier not allowed for function names.")
                                                                                               ^ Missing semicolon.
    888 |            value = this.scopeChain.resolveReference(node.name)
                                                                        ^ Missing semicolon.
    889 |            if(value != null && typeof value != 'undefined') {
                              ^ Use '!==' to compare with 'null'.

>> 3 errors in 4 files
```
